### PR TITLE
Fix PyPi installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CMakeLists.txt
+recursive-include TS2CG *.cpp *.h CMakeLists.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TS2CG"
-version = "1.2.0"
+version = "1.2.2"
 description = "TS2CG: converts triangulated surfaces to coarse-grained membrane models"
 requires-python = ">=3.6"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,14 @@ class CMakeBuild(build_ext):
 
 setup(
     name='TS2CG',
-    version='1.2.0',
+    version='1.2.2',
     packages=find_packages(),
     ext_modules=[CMakeExtension('TS2CG')],
     cmdclass={'build_ext': CMakeBuild},
-    package_data={'TS2CG': ['SOL', 'PLM', 'PCG']},
+    package_data={
+        'TS2CG': ['SOL', 'PLM', 'PCG', 'CMakeLists.txt',
+                  'Solvate/*', 'Pointillism/*', 'MembraneBuilder/*'],
+    },
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Even though building from source ('pip install .') worked, installing it from PyPi directly ('pip install TS2CG') didn't.

This error resulted from how the files were managed but this is fixed now. 